### PR TITLE
Stop tabIndex being overwritten on details element in IE 

### DIFF
--- a/app/assets/javascripts/details.polyfill.js
+++ b/app/assets/javascripts/details.polyfill.js
@@ -149,7 +149,10 @@
                 // Set tabIndex so the summary is keyboard accessible for non-native elements
                 // http://www.saliences.com/browserBugs/tabIndex.html
                 if (!GOVUK.details.NATIVE_DETAILS) {
-                    details.__summary.tabIndex = 0
+                    if (typeof details.__summary.tabIndex === 'undefined') {
+                        // the variable is undefined, so set to 0, otherwise we can just use existing
+                        details.__summary.tabIndex = 0
+                    }
                 }
 
                 // Detect initial open state


### PR DESCRIPTION
if it's already set.

Prior to this change, when using the Operational UI in IE11, the javascript included in pages explicitly always overwrote the tabindex of details elements to 0 for browsers that don't support details natively (e.g IE11). When we've set it ourselves to be something specific, we don't want that to happen.