### PR TITLE
DIT-1814 Fix bug with display of edit rulings link

### DIFF
--- a/app/connector/AuthenticatedHttpClient.scala
+++ b/app/connector/AuthenticatedHttpClient.scala
@@ -27,7 +27,6 @@ import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 import config.AppConfig
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/app/models/Permission.scala
+++ b/app/models/Permission.scala
@@ -245,7 +245,8 @@ object Permission {
   case object EDIT_RULING extends CasePermission {
     override def name: String = nameOf(this)
     override def appliesTo(`case`: Case, operator: Operator): Boolean =
-      `case`.hasStatus(CaseStatus.OPEN) && managersOrAssignedTeamMembersOnly(`case`, operator)
+      `case`.hasStatus(CaseStatus.OPEN, CaseStatus.REFERRED, CaseStatus.SUSPENDED) &&
+        managersOrAssignedTeamMembersOnly(`case`, operator)
   }
 
   case object APPEAL_CASE extends CasePermission {

--- a/app/models/viewmodels/RulingViewModel.scala
+++ b/app/models/viewmodels/RulingViewModel.scala
@@ -16,7 +16,7 @@
 
 package models.viewmodels
 
-import models.{Case, CaseStatus, Permission}
+import models.{Case, Permission}
 
 case class RulingViewModel(
                             commodityCodeEnteredByTraderOrAgent: String,
@@ -40,8 +40,6 @@ object RulingViewModel {
     val decisionMethodSearch = c.decision.fold("")(_.methodSearch.getOrElse(""))
     val decisionMethodExclusion = c.decision.fold("")(_.methodExclusion.getOrElse(""))
 
-    val showEditRuling = Set(CaseStatus.OPEN,CaseStatus.REFERRED,CaseStatus.SUSPENDED).contains(c.status) && permissions.contains(Permission.EDIT_RULING)
-
     RulingViewModel(
       commodityCodeEnteredByTraderOrAgent = c.application.asLiabilityOrder.traderCommodityCode.getOrElse(""),
       commodityCodeSuggestedByOfficer = c.application.asLiabilityOrder.officerCommodityCode.getOrElse(""),
@@ -50,7 +48,7 @@ object RulingViewModel {
       justification = decisionJustification,
       methodSearch = decisionMethodSearch,
       methodExclusion = decisionMethodExclusion,
-      showEditRuling,
+      showEditRuling = permissions.contains(Permission.EDIT_RULING),
       c.reference
     )
   }

--- a/test/unit/models/PermissionTest.scala
+++ b/test/unit/models/PermissionTest.scala
@@ -408,7 +408,7 @@ class PermissionTest extends UnitSpec {
       permission.appliesTo(caseWithValidStatus.copy(assignee = Some(teamMember)), teamMember) shouldBe true
       permission.appliesTo(caseWithValidStatus, manager) shouldBe true
 
-      for(status: CaseStatus <- CaseStatus.values.filterNot(equalTo(CaseStatus.OPEN))) {
+      for(status: CaseStatus <- CaseStatus.values.filterNot(Set(CaseStatus.OPEN, CaseStatus.REFERRED, CaseStatus.SUSPENDED))) {
         val caseWithInvalidStatus = aCase(withStatus(status))
         permission.appliesTo(caseWithInvalidStatus, readOnly) shouldBe false
         permission.appliesTo(caseWithInvalidStatus, teamMember) shouldBe false

--- a/test/unit/models/viewmodels/RulingViewModelTest.scala
+++ b/test/unit/models/viewmodels/RulingViewModelTest.scala
@@ -27,28 +27,10 @@ class RulingViewModelTest extends UnitSpec {
 
   "showEditRuling" should {
 
-    "show edit ruling button when case status is OPEN" in {
+    "show edit ruling button when we have EDIT_RULING permission" in {
       val aCase = dummyCase.copy(status = OPEN)
       val permissions: Set[Permission] = Set(Permission.EDIT_RULING)
       RulingViewModel.fromCase(aCase, permissions).showEditRuling shouldBe true
-    }
-
-    "show edit ruling button when case status is REFERRED" in {
-      val aCase = dummyCase.copy(status = REFERRED)
-      val permissions: Set[Permission] = Set(Permission.EDIT_RULING)
-      RulingViewModel.fromCase(aCase, permissions).showEditRuling shouldBe true
-    }
-
-    "show edit ruling button when case status is SUSPENDED" in {
-      val aCase = dummyCase.copy(status = SUSPENDED)
-      val permissions: Set[Permission] = Set(Permission.EDIT_RULING)
-      RulingViewModel.fromCase(aCase, permissions).showEditRuling shouldBe true
-    }
-
-    "not show edit ruling button because case status" in {
-      val aCase = dummyCase.copy(status = REJECTED)
-      val permissions: Set[Permission] = Set(Permission.EDIT_RULING)
-      RulingViewModel.fromCase(aCase, permissions).showEditRuling shouldBe false
     }
 
     "not show edit ruling button because permission is missing" in {


### PR DESCRIPTION
This issue arose because the logic checking whether to display the link was duplicated between the view model and the permission, so we have moved all the logic into the permission.