### PR TITLE
DIT-1814 Fix discrepancies between edit rulings functionality and prototype

### DIFF
--- a/app/views/partials/liabilities/ruling_tab.scala.html
+++ b/app/views/partials/liabilities/ruling_tab.scala.html
@@ -27,6 +27,8 @@
 
 @c592_information(rulingViewModel.commodityCodeEnteredByTraderOrAgent, rulingViewModel.commodityCodeSuggestedByOfficer)
 
+<hr>
+
 @*liability ruling*@
 <h3 class="heading-medium mt-30 mb-30">@messages("case.v2.liability.ruling.section")</h3>
 @if(rulingViewModel.showEditRuling) {

--- a/app/views/v2/edit_liability_ruling.scala.html
+++ b/app/views/v2/edit_liability_ruling.scala.html
@@ -52,7 +52,6 @@
 @input_text(
 field = form("bindingCommodityCode"),
 label = messages("case.liability.decision.bindingCommodityCode"),
-hint = Some("This is the commodity code that you think should be used by the importer."),
 formControlClass = Some("w-50")
 )
 


### PR DESCRIPTION
* Added horizontal rule between Information from the C592 and Liability Ruling on the Ruling tab
* Removed hint text from the edit liability ruling page Commodity Code field