### PR TITLE
DIT-1982 | Supporting line breaks in address fields from migrated data

### DIFF
--- a/app/views/partials/liabilities/c592_tab.scala.html
+++ b/app/views/partials/liabilities/c592_tab.scala.html
@@ -125,9 +125,9 @@
         @messages("case.v2.liability.c592.trader_address")
         </dt>
         <dd class="column-one-half" id="liability-trader-address">
-            <div>@c592ViewModel.traderContact.address.buildingAndStreet</div>
-            <div>@c592ViewModel.traderContact.address.townOrCity</div>
-            <div>@c592ViewModel.traderContact.address.county.getOrElse("")</div>
+            <div class="pre-wrap">@c592ViewModel.traderContact.address.buildingAndStreet</div>
+            <div class="pre-wrap">@c592ViewModel.traderContact.address.townOrCity</div>
+            <div class="pre-wrap">@c592ViewModel.traderContact.address.county.getOrElse("")</div>
             <div>@c592ViewModel.traderContact.address.postCode.getOrElse("")</div>
         </dd>
     </div>


### PR DESCRIPTION
This is a minor front-end change to support the following PR's

* https://github.com/hmrc/binding-tariff-data-transformation/pull/48
* https://github.com/hmrc/binding-tariff-admin-frontend/pull/65