### PR TITLE
Suppress warnings from generated code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,13 +21,19 @@ lazy val microservice = (project in file("."))
   .settings(PlayKeys.playDefaultPort := 9581)
   .settings(
     name := appName,
-    scalaVersion := "2.12.10",
+    scalaVersion := "2.12.12",
     targetJvm := "jvm-1.8",
     libraryDependencies ++= (AppDependencies.compile ++ AppDependencies.test).map(_ withSources()),
     evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
     parallelExecution in Test := false,
     fork in Test := true,
-    retrieveManaged := true
+    retrieveManaged := true,
+    // Use the silencer plugin to suppress warnings from unused imports in compiled twirl templates
+    scalacOptions += "-P:silencer:pathFilters=views;routes",
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.1" cross CrossVersion.full),
+      "com.github.ghik" % "silencer-lib" % "1.7.1" % Provided cross CrossVersion.full
+    )
   )
   .settings(inConfig(TemplateTest)(Defaults.testSettings): _*)
   .settings(


### PR DESCRIPTION
I added the silencer plugin to suppress warnings from generated code like routes files and views.