### PR TITLE
Restore this utterly inexplicable code

### DIFF
--- a/app/controllers/SampleController.scala
+++ b/app/controllers/SampleController.scala
@@ -52,7 +52,12 @@ class SampleController @Inject() (
     implicit request: AuthenticatedRequest[_]
   ): Html =
     c.application.`type` match {
-      case ApplicationType.LIABILITY => views.html.change_liablity_sending_sample(c, notFilledForm)
+      case ApplicationType.LIABILITY =>
+        if (options.contains("liability")) {
+          views.html.change_liablity_sending_sample(c, notFilledForm)
+        } else {
+          views.html.change_sample_status(c, notFilledForm)
+        }
       case ApplicationType.CORRESPONDENCE => views.html.change_correspondence_sending_sample(c, notFilledForm)
       case _ =>       views.html.change_sample_status(c, notFilledForm)
     }


### PR DESCRIPTION
Unfortunately the original logic here that we removed in #451 actually was needed.

Apparently the presence of this `&option=liability` query parameter actually sends you to a different page, and both permutations of this route are used for liabilities.

We should refactor this but I have spent all afternoon trying to get a fix into prod for something else and this is blocking the pipeline 😭 