### PR TITLE
Activity tab header change from "name" to "identifier"

### DIFF
--- a/app/views/partials/activity_details_events_table.scala.html
+++ b/app/views/partials/activity_details_events_table.scala.html
@@ -27,7 +27,7 @@
 <table id="activity-events">
     <thead>
         <tr>
-            <th scope="col">Name</th>
+            <th scope="col">Identifier</th>
             <th scope="col">Description</th>
             <th scope="col">Date</th>
 
@@ -36,7 +36,15 @@
     <tbody>
     @for((event: Event, index: Int) <- activity.events.results.zipWithIndex) {
         <tr id="activity-events-row-@{index}">
-            <td id="activity-events-row-@{index}-operator" class="activity-cell">@event.operator.name.getOrElse("Unknown")</td>
+            <td id="activity-events-row-@{index}-operator" class="activity-cell">
+                @if(event.operator.id.isEmpty){
+                @event.operator.name.getOrElse("Unknown")
+                }else{
+                @event.operator.id
+                }
+
+
+            </td>
 
             <td id="activity-events-row-@{index}-content" class="activity-cell-desc">
                 @{

--- a/app/views/partials/liabilities/activity_tab_events_table.scala.html
+++ b/app/views/partials/liabilities/activity_tab_events_table.scala.html
@@ -29,7 +29,7 @@
 <table id="activity-events">
     <thead>
         <tr>
-            <th scope="col">Name</th>
+            <th scope="col">Identifier</th>
             <th scope="col">Description</th>
             <th scope="col">Date</th>
 
@@ -38,7 +38,13 @@
     <tbody>
         @for((event: Event, index: Int) <- activityViewModel.events.results.zipWithIndex) {
             <tr id="activity-events-row-@{index}">
-                <td id="activity-events-row-@{index}-operator" class="activity-cell">@event.operator.id</td>
+                <td id="activity-events-row-@{index}-operator" class="activity-cell">
+                    @if(event.operator.id.isEmpty){
+                    @event.operator.name.getOrElse("Unknown")
+                    }else{
+                    @event.operator.id
+                    }
+                </td>
 
                 <td id="activity-events-row-@{index}-content" class="activity-cell-desc">
                 @{

--- a/test/unit/views/partials/ActivityDetailsViewSpec.scala
+++ b/test/unit/views/partials/ActivityDetailsViewSpec.scala
@@ -36,6 +36,46 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
     val requestWithAddNotePermission = requestWithPermissions(Permission.ADD_NOTE)
 
+    "Render event without operator id or name" in {
+      // Given
+      val c = aCase()
+      val e = Event(
+        id            = "EVENT_ID",
+        details       = Note("comment"),
+        operator      = Operator("", None),
+        caseReference = "ref"
+      )
+
+      val activityTab = ActivityViewModel.fromCase(c, Paged(Seq(e)), queues)
+
+      // When
+      val doc = view(activity_details(activityTab, ActivityForm.form))
+
+      // Then
+      doc                                                  should containElementWithID("activity-events-row-0-operator")
+      doc.getElementById("activity-events-row-0-operator") should containText("Unknown")
+    }
+
+    "Render event with operator id and name" in {
+      // Given
+      val c = aCase()
+      val e = Event(
+        id            = "EVENT_ID",
+        details       = Note("comment"),
+        operator      = Operator("id", Some("name")),
+        caseReference = "ref"
+      )
+
+      val activityTab = ActivityViewModel.fromCase(c, Paged(Seq(e)), queues)
+
+      // When
+      val doc = view(activity_details(activityTab, ActivityForm.form))
+
+      // Then
+      doc                                                  should containElementWithID("activity-events-row-0-operator")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
+    }
+
     "Render event without operator name" in {
       // Given
       val c = aCase()
@@ -53,7 +93,27 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("Unknown")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
+    }
+
+    "Render event without operator id " in {
+      // Given
+      val c = aCase()
+      val e = Event(
+        id            = "EVENT_ID",
+        details       = Note("comment"),
+        operator      = Operator("", Some("name")),
+        caseReference = "ref"
+      )
+
+      val activityTab = ActivityViewModel.fromCase(c, Paged(Seq(e)), queues)
+
+      // When
+      val doc = view(activity_details(activityTab, ActivityForm.form))
+
+      // Then
+      doc                                                  should containElementWithID("activity-events-row-0-operator")
+      doc.getElementById("activity-events-row-0-operator") should containText("name")
     }
 
     "Render 'Add Note' when user has permission" in {
@@ -116,7 +176,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("name")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
       doc                                                  should containElementWithID("activity-events-row-0-content")
       doc.getElementById("activity-events-row-0-content")  should containText("comment")
       doc                                                  should containElementWithID("activity-events-row-0-date")
@@ -146,7 +206,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("name")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
       doc                                                  should containElementWithID("activity-events-row-0-content")
       doc.getElementById("activity-events-row-0-content")  should containText("Status changed from open to completed")
       doc                                                  should containElementWithID("activity-events-row-0-comment")
@@ -183,7 +243,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("name")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
       doc                                                  should containElementWithID("activity-events-row-0-content")
       doc.getElementById("activity-events-row-0-content")  should containText("Status changed from open to cancelled")
       doc                                                  should containElementWithID("activity-events-row-0-comment")
@@ -225,7 +285,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("name")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
       doc                                                  should containElementWithID("activity-events-row-0-content")
       doc.getElementById("activity-events-row-0-content")  should containText("Status changed from open to referred")
       doc                                                  should containElementWithID("activity-events-row-0-comment")
@@ -267,7 +327,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
         // Then
         doc                                                  should containElementWithID("activity-events-row-0-operator")
-        doc.getElementById("activity-events-row-0-operator") should containText("name")
+        doc.getElementById("activity-events-row-0-operator") should containText("id")
         doc                                                  should containElementWithID("activity-events-row-0-content")
         doc.getElementById("activity-events-row-0-content")  should containText("Status changed from open to completed")
         doc                                                  should containElementWithID("activity-events-row-0-comment")
@@ -296,7 +356,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
         // Then
         doc                                                  should containElementWithID("activity-events-row-0-operator")
-        doc.getElementById("activity-events-row-0-operator") should containText("name")
+        doc.getElementById("activity-events-row-0-operator") should containText("id")
         doc                                                  should containElementWithID("activity-events-row-0-content")
         doc.getElementById("activity-events-row-0-content")  should containText("Status changed from open to completed")
         doc                                                  should containElementWithID("activity-events-row-0-comment")
@@ -329,7 +389,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("name")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
       doc                                                  should containElementWithID("activity-events-row-0-content")
       doc.getElementById("activity-events-row-0-content") should containText(
         "Appeal added with type Appeal tier 1 and status Under appeal"
@@ -361,7 +421,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("name")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
       doc                                                  should containElementWithID("activity-events-row-0-content")
       doc.getElementById("activity-events-row-0-content")  should containText("Review added with status Under review")
       doc.getElementById("activity-events-row-0-content")  should containText("comment")
@@ -395,7 +455,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("name")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
       doc                                                  should containElementWithID("activity-events-row-0-content")
       doc.getElementById("activity-events-row-0-content") should containText(
         "Appeal tier 1 status changed from Under appeal to Appeal allowed"
@@ -423,7 +483,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("name")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
       doc                                                  should containElementWithID("activity-events-row-0-content")
       doc.getElementById("activity-events-row-0-content")  should containText("Expert advice received")
       doc.getElementById("activity-events-row-0-content")  should containText("advice paragraph")
@@ -449,7 +509,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("name")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
       doc                                                  should containElementWithID("activity-events-row-0-content")
       doc.getElementById("activity-events-row-0-content") should containText(
         "Application for extended use status changed from No to Yes"
@@ -477,7 +537,7 @@ class ActivityDetailsViewSpec extends ViewSpec {
 
       // Then
       doc                                                  should containElementWithID("activity-events-row-0-operator")
-      doc.getElementById("activity-events-row-0-operator") should containText("name")
+      doc.getElementById("activity-events-row-0-operator") should containText("id")
       doc.getElementById("activity-events-row-0-content")  should containText("comment")
       doc                                                  should containElementWithID("activity-events-row-0-date")
       doc.getElementById("activity-events-row-0-date")     should containText("01 Jan 2019")


### PR DESCRIPTION
changed the header from name to identifier and also display operator id when its present rather than always displaying name as per prototype