### PR TITLE
Revert the revert of Dit 2759 | Refactor keywords for ATaRs and liabilities

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -17,11 +17,16 @@
 package config
 
 import java.time.Clock
+import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
+
 import play.api.Mode.Mode
 import play.api.{Configuration, Environment, Mode}
 import uk.gov.hmrc.play.bootstrap.binders.SafeRedirectUrl
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import scala.concurrent.duration.FiniteDuration
+
 @Singleton
 class AppConfig @Inject() (
   config: Configuration,
@@ -73,6 +78,11 @@ class AppConfig @Inject() (
       accessibilityBaseUrl + referrer).encodedUrl}"
 
   lazy val maxUriLength: Long = config.underlying.getBytes("akka.http.parsing.max-uri-length")
+
+  lazy val keywordsCacheExpiration: FiniteDuration = {
+    val javaDuration = config.underlying.getDuration("keywords-cache.expiration")
+    FiniteDuration(javaDuration.toMillis(), TimeUnit.MILLISECONDS)
+  }
 
   lazy val clock: Clock = Clock.systemUTC()
 

--- a/app/connector/BindingTariffClassificationConnector.scala
+++ b/app/connector/BindingTariffClassificationConnector.scala
@@ -275,12 +275,6 @@ class BindingTariffClassificationConnector @Inject() (
       client.POST[NewKeywordRequest, Keyword](url, NewKeywordRequest(keyword))
     }
 
-  def findKeyword(keywordName: String)(implicit hc: HeaderCarrier): Future[Option[Keyword]] =
-    withMetricsTimerAsync("find-keyword") { _ =>
-      val url = s"${appConfig.bindingTariffClassificationUrl}/keyword/$keywordName"
-      client.GET[Option[Keyword]](url)
-    }
-
   def findAllKeywords(pagination: Pagination)(implicit hc: HeaderCarrier): Future[Paged[Keyword]] =
     withMetricsTimerAsync("find-all-keywords") { _ =>
       val url = s"${appConfig.bindingTariffClassificationUrl}/keywords?page=${pagination.page}&page_size=${pagination.pageSize}"

--- a/app/connector/BindingTariffClassificationConnector.scala
+++ b/app/connector/BindingTariffClassificationConnector.scala
@@ -275,6 +275,12 @@ class BindingTariffClassificationConnector @Inject() (
       client.POST[NewKeywordRequest, Keyword](url, NewKeywordRequest(keyword))
     }
 
+  def findKeyword(keywordName: String)(implicit hc: HeaderCarrier): Future[Option[Keyword]] =
+    withMetricsTimerAsync("find-keyword") { _ =>
+      val url = s"${appConfig.bindingTariffClassificationUrl}/keyword/$keywordName"
+      client.GET[Option[Keyword]](url)
+    }
+
   def findAllKeywords(pagination: Pagination)(implicit hc: HeaderCarrier): Future[Paged[Keyword]] =
     withMetricsTimerAsync("find-all-keywords") { _ =>
       val url = s"${appConfig.bindingTariffClassificationUrl}/keywords?page=${pagination.page}&page_size=${pagination.pageSize}"

--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -56,7 +56,7 @@ class SearchController @Inject() (
     implicit request =>
       val focus: SearchTab = if (addToSearch.contains(true)) SearchTab.SEARCH_BOX else selectedTab
       def defaultAction: Future[Result] =
-        keywordsService.findAll(NoPagination()).map { keywords: Paged[Keyword] =>
+        keywordsService.findAll.map { keywords: Paged[Keyword] =>
           Results.Ok(html.advanced_search(SearchForm.form, None, keywords.results.map(_.name), focus))
         }
 
@@ -76,7 +76,7 @@ class SearchController @Inject() (
       } else if (search.isEmpty) {
         defaultAction
       } else {
-        keywordsService.findAll(NoPagination()).flatMap { keywords =>
+        keywordsService.findAll.flatMap { keywords =>
           SearchForm.form.bindFromRequest.fold(
             formWithErrors =>
               Future.successful(Results.Ok(html.advanced_search(formWithErrors, None, keywords.results.map(_.name), focus))),

--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -56,8 +56,8 @@ class SearchController @Inject() (
     implicit request =>
       val focus: SearchTab = if (addToSearch.contains(true)) SearchTab.SEARCH_BOX else selectedTab
       def defaultAction: Future[Result] =
-        keywordsService.autoCompleteKeywords.map { keywords: Seq[String] =>
-          Results.Ok(html.advanced_search(SearchForm.form, None, keywords, focus))
+        keywordsService.findAll(NoPagination()).map { keywords: Paged[Keyword] =>
+          Results.Ok(html.advanced_search(SearchForm.form, None, keywords.results.map(_.name), focus))
         }
 
       if (reference.isDefined) {
@@ -76,17 +76,17 @@ class SearchController @Inject() (
       } else if (search.isEmpty) {
         defaultAction
       } else {
-        keywordsService.autoCompleteKeywords.flatMap { keywords =>
+        keywordsService.findAll(NoPagination()).flatMap { keywords =>
           SearchForm.form.bindFromRequest.fold(
             formWithErrors =>
-              Future.successful(Results.Ok(html.advanced_search(formWithErrors, None, keywords, focus))),
+              Future.successful(Results.Ok(html.advanced_search(formWithErrors, None, keywords.results.map(_.name), focus))),
             data =>
               for {
                 cases: Paged[Case]                            <- casesService.search(search, sort, SearchPagination(page))
                 attachments: Map[Case, Seq[StoredAttachment]] <- fileStoreService.getAttachments(cases.results)
                 results: Paged[SearchResult] = cases.map(c => SearchResult(c, attachments.getOrElse(c, Seq.empty)))
               } yield Results
-                .Ok(html.advanced_search(SearchForm.form.fill(data), Some(results), keywords, focus))
+                .Ok(html.advanced_search(SearchForm.form.fill(data), Some(results), keywords.results.map(_.name), focus))
                 .addingToSession(
                   (backToSearchResultsLinkLabel, "search results"),
                   (

--- a/app/controllers/v2/AtarController.scala
+++ b/app/controllers/v2/AtarController.scala
@@ -117,7 +117,7 @@ class AtarController @Inject() (
     } yield ActivityViewModel.fromCase(atarCase, events, queues)
 
   private def getKeywordsTab(atarCase: Case)(implicit hc: HeaderCarrier): Future[KeywordsTabViewModel] =
-    keywordsService.findAll(NoPagination()).map { globalKeywords =>
+    keywordsService.findAll.map { globalKeywords =>
       KeywordsTabViewModel.fromCase(atarCase, globalKeywords.results.map(_.name))
     }
 }

--- a/app/controllers/v2/AtarController.scala
+++ b/app/controllers/v2/AtarController.scala
@@ -116,8 +116,8 @@ class AtarController @Inject() (
       queues <- queuesService.getAll
     } yield ActivityViewModel.fromCase(atarCase, events, queues)
 
-  private def getKeywordsTab(atarCase: Case): Future[KeywordsTabViewModel] =
-    keywordsService.autoCompleteKeywords.map { globalKeywords =>
-      KeywordsTabViewModel.fromCase(atarCase, globalKeywords)
+  private def getKeywordsTab(atarCase: Case)(implicit hc: HeaderCarrier): Future[KeywordsTabViewModel] =
+    keywordsService.findAll(NoPagination()).map { globalKeywords =>
+      KeywordsTabViewModel.fromCase(atarCase, globalKeywords.results.map(_.name))
     }
 }

--- a/app/controllers/v2/LiabilityController.scala
+++ b/app/controllers/v2/LiabilityController.scala
@@ -72,7 +72,7 @@ class LiabilityController @Inject() (
       sampleTab                <- getSampleTab(liabilityCase)
       c592        = Some(C592ViewModel.fromCase(liabilityCase))
       activityTab = Some(ActivityViewModel.fromCase(liabilityCase, activityEvents, queues))
-      keywordsTab <- keywordsService.findAll(NoPagination()).map(kws =>
+      keywordsTab <- keywordsService.findAll.map(kws =>
                       KeywordsTabViewModel(liabilityCase.reference, liabilityCase.keywords, kws.results.map(_.name))
                     )
     } yield {

--- a/app/controllers/v2/LiabilityController.scala
+++ b/app/controllers/v2/LiabilityController.scala
@@ -72,8 +72,8 @@ class LiabilityController @Inject() (
       sampleTab                <- getSampleTab(liabilityCase)
       c592        = Some(C592ViewModel.fromCase(liabilityCase))
       activityTab = Some(ActivityViewModel.fromCase(liabilityCase, activityEvents, queues))
-      keywordsTab <- keywordsService.autoCompleteKeywords.map(kws =>
-                      KeywordsTabViewModel(liabilityCase.reference, liabilityCase.keywords, kws)
+      keywordsTab <- keywordsService.findAll(NoPagination()).map(kws =>
+                      KeywordsTabViewModel(liabilityCase.reference, liabilityCase.keywords, kws.results.map(_.name))
                     )
     } yield {
       Ok(

--- a/app/models/viewmodels/managementtools/ManageKeywordsViewModel.scala
+++ b/app/models/viewmodels/managementtools/ManageKeywordsViewModel.scala
@@ -53,7 +53,7 @@ object ManageKeywordsViewModel {
           caseHeader.goodsName.getOrElse(""),
           caseHeader.caseType,
           caseStatus,
-          caseKeyword.keyword.approved
+          allKeywords.contains(caseKeyword.keyword.name)
         )
     })
 

--- a/app/service/KeywordsService.scala
+++ b/app/service/KeywordsService.scala
@@ -25,7 +25,6 @@ import models._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
-import scala.io.Source
 
 @Singleton
 class KeywordsService @Inject() (connector: BindingTariffClassificationConnector, auditService: AuditService) {
@@ -52,10 +51,7 @@ class KeywordsService @Inject() (connector: BindingTariffClassificationConnector
       successful(c)
     }
 
-  def autoCompleteKeywords: Future[Seq[String]] =
-    Future {
-      val url = getClass.getClassLoader.getResource("keywords.txt")
-      (for (line <- Source.fromURL(url, "UTF-8").getLines()) yield line).toSeq
-    }
+  def findAll(pagination: Pagination)(implicit hc: HeaderCarrier): Future[Paged[Keyword]] =
+    connector.findAllKeywords(pagination)
 
 }

--- a/app/views/managementtools/all_keywords.scala.html
+++ b/app/views/managementtools/all_keywords.scala.html
@@ -25,22 +25,18 @@
 
     <div class="govuk-form-group">
         <div id="advanced_search_keywords">
-            <div class="display-inline w-75">
-                <label class="form-label" for="keyword_0">
-                    <span>Rename or delete a keyword from the approved list</span>
-                </label>
-                <span class="form-hint"></span>
-            </div>
             <div class="w-75 left display-inline">
                 @input_accessible_auto_complete(
                     field = keywordForm("keyword"),
+                    label = Some(messages("management.manage-keywords.search-all-keywords.label")),
                     formControlClass = Some("w-100"),
+                    labelClass = Some("un-bold"),
                     autoCompleteOptions = keywordsTabViewModel.globalKeywords,
                     placeholder = Some(messages("management.manage-keywords.search-all-keywords.placeholder"))
                 )
             </div>
-            <button id="keyword_search-edit-keyword-button" class="button left ml-1" type="submit" name="editKeyword" value="true">
-                Edit keyword
+            <button id="keyword_search-edit-keyword-button" class="button left ml-1 mt-2" type="submit" name="editKeyword" value="true">
+                @messages("management.manage-keywords.search-all-keywords.edit-keyword-button")
             </button>
         </div>
     </div>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -200,3 +200,7 @@ mongodb {
   uri = "mongodb://localhost:27017/"${appName}
   timeToLiveInSeconds = 3600
 }
+
+keywords-cache {
+  expiration = 2 minutes
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,12 +4,13 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc"   %% "bootstrap-frontend-play-27" % "2.25.0",
-    "uk.gov.hmrc"   %% "play-ui"                    % "8.14.0-play-27",
-    "uk.gov.hmrc"   %% "http-caching-client"        % "9.1.0-play-27",
-    "uk.gov.hmrc"   %% "simple-reactivemongo"       % "7.30.0-play-27",
-    "uk.gov.hmrc"   %% "play-json-union-formatter"  % "1.12.0-play-27",
-    "org.typelevel" %% "cats-core"                  % "2.2.0"
+    "uk.gov.hmrc"        %% "bootstrap-frontend-play-27" % "2.25.0",
+    "uk.gov.hmrc"        %% "play-ui"                    % "8.14.0-play-27",
+    "uk.gov.hmrc"        %% "http-caching-client"        % "9.1.0-play-27",
+    "uk.gov.hmrc"        %% "simple-reactivemongo"       % "7.30.0-play-27",
+    "uk.gov.hmrc"        %% "play-json-union-formatter"  % "1.12.0-play-27",
+    "org.typelevel"      %% "cats-core"                  % "2.4.2",
+    "com.github.blemale" %% "scaffeine"                  % "4.0.2"
   )
 
   val scope = "test, it"

--- a/test/it/integration/AppealCaseSpec.scala
+++ b/test/it/integration/AppealCaseSpec.scala
@@ -1,11 +1,11 @@
 package integration
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import models.{CaseStatus, Operator, Role, Pagination}
+import models.{CaseStatus, Operator, Pagination, Role}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.ws.WSResponse
 import play.api.test.Helpers._
-import utils.{CasePayloads, EventPayloads}
+import utils.{CasePayloads, EventPayloads, KeywordsPayloads}
 import utils.Cases.{aCase, withDecision}
 import utils.JsonFormatters._
 
@@ -86,6 +86,17 @@ class AppealCaseSpec extends IntegrationTest with MockitoSugar {
               .withStatus(OK)
               .withBody(EventPayloads.pagedEvents)
           )
+      )
+      stubFor(
+        get(
+          urlEqualTo(
+            s"/keywords?page=1&page_size=${Pagination.unlimited}"
+          )
+        ).willReturn(
+          aResponse()
+            .withStatus(OK)
+            .withBody(KeywordsPayloads.pagedKeywords)
+        )
       )
 
       // When

--- a/test/it/integration/CaseSpec.scala
+++ b/test/it/integration/CaseSpec.scala
@@ -5,7 +5,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import models.{Case, Pagination}
 import utils.Cases._
-import utils.{CasePayloads, EventPayloads}
+import utils.{CasePayloads, EventPayloads, KeywordsPayloads}
 import utils.JsonFormatters._
 
 class CaseSpec extends IntegrationTest with MockitoSugar {
@@ -79,6 +79,17 @@ class CaseSpec extends IntegrationTest with MockitoSugar {
               .withStatus(OK)
               .withBody(EventPayloads.pagedEvents)
           )
+      )
+      stubFor(
+        get(
+          urlEqualTo(
+            s"/keywords?page=1&page_size=${Pagination.unlimited}"
+          )
+        ).willReturn(
+          aResponse()
+            .withStatus(OK)
+            .withBody(KeywordsPayloads.pagedKeywords)
+        )
       )
 
       // When

--- a/test/it/integration/LiabilitySpec.scala
+++ b/test/it/integration/LiabilitySpec.scala
@@ -1,11 +1,11 @@
 package integration
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.{stubFor, _}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import models.{Case, Pagination}
 import utils.Cases._
-import utils.{CasePayloads, EventPayloads}
+import utils.{CasePayloads, EventPayloads, KeywordsPayloads}
 import utils.JsonFormatters._
 
 class LiabilitySpec extends IntegrationTest with MockitoSugar {
@@ -58,6 +58,17 @@ class LiabilitySpec extends IntegrationTest with MockitoSugar {
             .withBody(EventPayloads.pagedEmpty)
         )
       )
+      stubFor(
+        get(
+          urlEqualTo(
+            s"/keywords?page=1&page_size=${Pagination.unlimited}"
+          )
+        ).willReturn(
+          aResponse()
+            .withStatus(OK)
+            .withBody(KeywordsPayloads.pagedKeywords)
+        )
+        )
 
       // When
       val response = await(ws.url(s"$baseUrl/cases/v2/1/liability").get())

--- a/test/it/integration/SearchSpec.scala
+++ b/test/it/integration/SearchSpec.scala
@@ -1,10 +1,10 @@
 package integration
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.{stubFor, _}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import models.Pagination
-import utils.{CasePayloads, EventPayloads}
+import utils.{CasePayloads, EventPayloads, KeywordsPayloads}
 
 class SearchSpec extends IntegrationTest with MockitoSugar {
 
@@ -49,6 +49,17 @@ class SearchSpec extends IntegrationTest with MockitoSugar {
               .withStatus(OK)
               .withBody(EventPayloads.pagedEvents)
           )
+      )
+      stubFor(
+        get(
+          urlEqualTo(
+            s"/keywords?page=1&page_size=${Pagination.unlimited}"
+          )
+        ).willReturn(
+          aResponse()
+            .withStatus(OK)
+            .withBody(KeywordsPayloads.pagedKeywords)
+        )
       )
 
       // When

--- a/test/unit/controllers/SearchControllerSpec.scala
+++ b/test/unit/controllers/SearchControllerSpec.scala
@@ -85,7 +85,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
       given(casesService.getOne(ArgumentMatchers.eq("reference"))(any[HeaderCarrier])) willReturn Future.successful(
         None
       )
-      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
+      given(keywordsService.findAll) willReturn Future.successful(Paged(Seq.empty[Keyword]))
       val result = await(controller.search(defaultTab, reference = Some("reference"), page = 2)(fakeRequest))
 
       status(result)          shouldBe Status.OK
@@ -96,7 +96,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
     }
 
     "render the advanced search page if searching by reference but it is empty" in {
-      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
+      given(keywordsService.findAll) willReturn Future.successful(Paged(Seq.empty[Keyword]))
       val result = await(controller.search(defaultTab, reference = Some(" "), page = 2)(fakeRequest))
 
       status(result)          shouldBe Status.OK
@@ -112,7 +112,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
       given(fileStoreService.getAttachments(refEq(Seq.empty))(any[HeaderCarrier])) willReturn Future.successful(
         Map.empty[Case, Seq[StoredAttachment]]
       )
-      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
+      given(keywordsService.findAll) willReturn Future.successful(Paged(Seq.empty[Keyword]))
 
       val result = await(controller.search(defaultTab, search = Search(), page = 2)(fakeRequest))
 
@@ -146,7 +146,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
       given(fileStoreService.getAttachments(refEq(Seq(c)))(any[HeaderCarrier])) willReturn Future.successful(
         Map(c -> Seq(attachment))
       )
-      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
+      given(keywordsService.findAll) willReturn Future.successful(Paged(Seq.empty[Keyword]))
 
       // When
       val request = fakeRequest.withFormUrlEncodedBody(
@@ -172,7 +172,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
       // Given
       val search = Search(traderName = Some("trader"))
 
-      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
+      given(keywordsService.findAll) willReturn Future.successful(Paged(Seq.empty[Keyword]))
 
       // When
       val request = fakeRequest.withFormUrlEncodedBody("commodity_code" -> "a")
@@ -210,7 +210,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
       given(fileStoreService.getAttachments(refEq(Seq(c)))(any[HeaderCarrier])) willReturn Future.successful(
         Map(c -> Seq(attachment))
       )
-      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
+      given(keywordsService.findAll) willReturn Future.successful(Paged(Seq.empty[Keyword]))
 
       // When
       val request = fakeRequest.withFormUrlEncodedBody(

--- a/test/unit/controllers/SearchControllerSpec.scala
+++ b/test/unit/controllers/SearchControllerSpec.scala
@@ -85,7 +85,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
       given(casesService.getOne(ArgumentMatchers.eq("reference"))(any[HeaderCarrier])) willReturn Future.successful(
         None
       )
-      given(keywordsService.autoCompleteKeywords) willReturn Future.successful(Seq.empty[String])
+      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
       val result = await(controller.search(defaultTab, reference = Some("reference"), page = 2)(fakeRequest))
 
       status(result)          shouldBe Status.OK
@@ -96,7 +96,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
     }
 
     "render the advanced search page if searching by reference but it is empty" in {
-      given(keywordsService.autoCompleteKeywords) willReturn Future.successful(Seq.empty[String])
+      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
       val result = await(controller.search(defaultTab, reference = Some(" "), page = 2)(fakeRequest))
 
       status(result)          shouldBe Status.OK
@@ -112,7 +112,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
       given(fileStoreService.getAttachments(refEq(Seq.empty))(any[HeaderCarrier])) willReturn Future.successful(
         Map.empty[Case, Seq[StoredAttachment]]
       )
-      given(keywordsService.autoCompleteKeywords) willReturn Future.successful(Seq.empty[String])
+      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
 
       val result = await(controller.search(defaultTab, search = Search(), page = 2)(fakeRequest))
 
@@ -146,7 +146,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
       given(fileStoreService.getAttachments(refEq(Seq(c)))(any[HeaderCarrier])) willReturn Future.successful(
         Map(c -> Seq(attachment))
       )
-      given(keywordsService.autoCompleteKeywords) willReturn Future.successful(Seq.empty[String])
+      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
 
       // When
       val request = fakeRequest.withFormUrlEncodedBody(
@@ -172,7 +172,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
       // Given
       val search = Search(traderName = Some("trader"))
 
-      given(keywordsService.autoCompleteKeywords) willReturn Future.successful(Seq.empty[String])
+      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
 
       // When
       val request = fakeRequest.withFormUrlEncodedBody("commodity_code" -> "a")
@@ -210,7 +210,7 @@ class SearchControllerSpec extends ControllerBaseSpec {
       given(fileStoreService.getAttachments(refEq(Seq(c)))(any[HeaderCarrier])) willReturn Future.successful(
         Map(c -> Seq(attachment))
       )
-      given(keywordsService.autoCompleteKeywords) willReturn Future.successful(Seq.empty[String])
+      given(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) willReturn Future.successful(Paged(Seq.empty[Keyword]))
 
       // When
       val request = fakeRequest.withFormUrlEncodedBody(

--- a/test/unit/controllers/v2/LiabilityControllerSpec.scala
+++ b/test/unit/controllers/v2/LiabilityControllerSpec.scala
@@ -140,7 +140,7 @@ class LiabilityControllerSpec extends ControllerBaseSpec with BeforeAndAfterEach
 
     when(fileStoreService.getAttachments(any[Case]())(any())) thenReturn (Future.successful(attachments))
     when(fileStoreService.getLetterOfAuthority(any[Case]())(any())) thenReturn (Future.successful(letterOfAuthority))
-    when(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) thenReturn Future(Paged(Seq(keyword1, keyword2)))
+    when(keywordsService.findAll) thenReturn Future(Paged(Seq(keyword1, keyword2)))
     when(keywordsService.addKeyword(any[Case](), any[String](), any[Operator]())(any())) thenReturn Future(
       Cases.liabilityLiveCaseExample
     )

--- a/test/unit/controllers/v2/LiabilityControllerSpec.scala
+++ b/test/unit/controllers/v2/LiabilityControllerSpec.scala
@@ -18,11 +18,13 @@ package controllers.v2
 
 import com.google.inject.Provider
 import controllers.{ControllerBaseSpec, RequestActions, RequestActionsWithPermissions}
+
 import javax.inject.Inject
 import models.forms.CommodityCodeConstraints
 import models.forms.v2.LiabilityDetailsForm
 import models.{Case, _}
-import org.mockito.ArgumentMatchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.{any, refEq, eq => meq}
 import org.mockito.Mockito.{times, _}
 import org.scalatest.BeforeAndAfterEach
 import play.api.Application
@@ -99,6 +101,9 @@ class LiabilityControllerSpec extends ControllerBaseSpec with BeforeAndAfterEach
   private lazy val keywordsService          = mock[KeywordsService]
   private lazy val casesService             = mock[CasesService]
 
+  private val keyword1: Keyword = Keyword("keyword1")
+  private val keyword2: Keyword = Keyword("keyword2")
+
   override def beforeEach(): Unit =
     reset(
       liability_view,
@@ -135,7 +140,7 @@ class LiabilityControllerSpec extends ControllerBaseSpec with BeforeAndAfterEach
 
     when(fileStoreService.getAttachments(any[Case]())(any())) thenReturn (Future.successful(attachments))
     when(fileStoreService.getLetterOfAuthority(any[Case]())(any())) thenReturn (Future.successful(letterOfAuthority))
-    when(keywordsService.autoCompleteKeywords) thenReturn Future(Seq("keyword1", "keyword2"))
+    when(keywordsService.findAll(any[Pagination])(any[HeaderCarrier])) thenReturn Future(Paged(Seq(keyword1, keyword2)))
     when(keywordsService.addKeyword(any[Case](), any[String](), any[Operator]())(any())) thenReturn Future(
       Cases.liabilityLiveCaseExample
     )

--- a/test/unit/service/KeywordsServiceSpec.scala
+++ b/test/unit/service/KeywordsServiceSpec.scala
@@ -33,7 +33,7 @@ class KeywordsServiceSpec extends ServiceSpecBase with BeforeAndAfterEach {
   private val connector    = mock[BindingTariffClassificationConnector]
   private val auditService = mock[AuditService]
 
-  private val service = new KeywordsService(connector, auditService)
+  private val service = new KeywordsService(realAppConfig, connector, auditService)
 
   private val operator: Operator = Operator("operator-id", None)
   private val aCase              = Cases.btiCaseExample
@@ -127,7 +127,7 @@ class KeywordsServiceSpec extends ServiceSpecBase with BeforeAndAfterEach {
     "return a list of keywords" in {
       given(connector.findAllKeywords(any[Pagination])(any[HeaderCarrier])) willReturn successful(Paged(Seq(keyword)))
 
-      await(service.findAll(NoPagination())) shouldBe Paged(Seq(keyword))
+      await(service.findAll) shouldBe Paged(Seq(keyword))
     }
   }
 

--- a/test/unit/service/KeywordsServiceSpec.scala
+++ b/test/unit/service/KeywordsServiceSpec.scala
@@ -38,6 +38,8 @@ class KeywordsServiceSpec extends ServiceSpecBase with BeforeAndAfterEach {
   private val operator: Operator = Operator("operator-id", None)
   private val aCase              = Cases.btiCaseExample
 
+  private val keyword: Keyword = Keyword("TEST")
+
   override protected def afterEach(): Unit = {
     super.afterEach()
     reset(connector, auditService)
@@ -123,7 +125,9 @@ class KeywordsServiceSpec extends ServiceSpecBase with BeforeAndAfterEach {
   "Retrieve auto complete keywords" should {
 
     "return a list of keywords" in {
-      await(service.autoCompleteKeywords) should contain("ABS")
+      given(connector.findAllKeywords(any[Pagination])(any[HeaderCarrier])) willReturn successful(Paged(Seq(keyword)))
+
+      await(service.findAll(NoPagination())) shouldBe Paged(Seq(keyword))
     }
   }
 

--- a/test/util/utils/Keywords.scala
+++ b/test/util/utils/Keywords.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import models.{Keyword, Paged}
+
+object Keywords {
+
+  val keyword1: Keyword = Keyword("keyword1")
+  val keyword2: Keyword = Keyword("keyword2")
+
+  val keywords = Seq(keyword1, keyword2)
+  val pagedKeywords: Paged[Keyword] = Paged(keywords)
+
+
+
+}

--- a/test/util/utils/KeywordsPayloads.scala
+++ b/test/util/utils/KeywordsPayloads.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import play.api.libs.json.{Json, Writes}
+import utils.JsonFormatters.keywordFormat
+
+object KeywordsPayloads {
+
+  val pagedKeywords = jsonOf(Keywords.pagedKeywords)
+
+  def jsonOf[A: Writes](obj: A): String =
+    Json.toJson(obj).toString()
+
+}


### PR DESCRIPTION
Reverts hmrc/tariff-classification-frontend#529

I have added a keywords cache that expires after 2 minutes. I hope that this will address some of the performance issues related to loading all keywords whenever we load the case page.