### PR TITLE
Don't use HMRC form helper for Upscan forms as it adds a CSRF token

### DIFF
--- a/app/views/partials/attachments_details.scala.html
+++ b/app/views/partials/attachments_details.scala.html
@@ -20,7 +20,6 @@
 @import models.request.AuthenticatedRequest
 @import models.response.FileStoreInitiateResponse
 @import models.viewmodels.atar.AttachmentsTabViewModel
-@import uk.gov.hmrc.play.views.html.helpers
 @import views.html.components.input_file
 @import views.html.partials.{attachments_list_atar, attachments_state_message, tab_heading, error_summary}
 
@@ -37,7 +36,7 @@
     @attachments_list_atar("classification-team", attachments, startAtTabIndex = Some(startAtTabIndex+31))
 
     @if(request.hasPermission(Permission.ADD_ATTACHMENT)) {
-        @helpers.form(
+        @helper.form(
             action = Call("POST", initiateResponse.uploadRequest.href),
             'enctype -> "multipart/form-data",
             'id -> "upload-files-form"

--- a/app/views/partials/liabilities/attachments_details.scala.html
+++ b/app/views/partials/liabilities/attachments_details.scala.html
@@ -21,7 +21,6 @@
 @import models.request.AuthenticatedRequest
 @import models.response.FileStoreInitiateResponse
 @import models.viewmodels.AttachmentsTabViewModel
-@import uk.gov.hmrc.play.views.html.helpers
 @import views.html.components.input_file
 @import views.html.partials.{attachments_state_message, tab_heading, error_summary}
 
@@ -51,7 +50,7 @@
 )
 
 @if(showUploadAttachments) {
-    @helpers.form(
+    @helper.form(
         action = Call("POST", initiateResponse.uploadRequest.href),
         'enctype -> "multipart/form-data",
         'id -> "upload-files-form"


### PR DESCRIPTION
I overlooked that these upload forms were using the HMRC form helper. This is a problem because it adds a CSRF token, which S3 rejects because it is not a field that it expects in the presigned request.