### PR TITLE
DDCE-3642: remove all references to covid from cover letter

### DIFF
--- a/app/views/templates/cover_letter_template.scala.html
+++ b/app/views/templates/cover_letter_template.scala.html
@@ -506,17 +506,11 @@ border: 1px solid #00703C;
                     You cannot ask for a review with HMRC and an appeal with an independent tribunal at the same time. However, you can appeal to an independent tribunal if you disagree with the outcome of your review.
                 </p>
                 <p class="govuk-body-s">
-                    Due to coronavirus (COVID-19), you will be able to ask for an extra 3 months for your appeals. This is for both an HMRC review and the independent tribunal.
-                </p>
-                <p class="govuk-body-s">
                     To find more information about reviews and appeals you can <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/877291/HMRC1.pdf">read the HMRC1 document</a> or phone 0300 200 3700.
                 </p>
                 <h4 class="heading-small">Asking for a review with HMRC</h4>
                 <p class="govuk-body-s">
                     Email <strong>@messages("pdf.ruling.email")</strong> asking for a review and give your reasons within 30 days of receiving your ruling email.
-                </p>
-                <p class="govuk-body-s">
-                    However, if you need more time due to coronavirus, you can be given an extra 3 months if the extension is asked for within this 30 day period.
                 </p>
                 <p class="govuk-body-s">
                     If you accept an offer for a review of the ruling decision, it will be carried out by an HMRC officer who has not been involved in your case. You will be able to give any evidence and further information and the review officer will email you to tell you the outcome of the review.


### PR DESCRIPTION
Remove the sentence of "However, if you need more time due to coronavirus, you can be given an extra 3 months if the extension is asked for within these 30 days."  & "Due to coronavirus (COVID-19), you will be able to ask for an extra 3 months for your appeals. This is for both an HMRC review and the independent tribunal. " from all ATaR letters. 